### PR TITLE
修复自动群名片失效 新增多项配置

### DIFF
--- a/basic-manager/src/main/java/com/illtamer/infinite/bot/expansion/basic/listener/MemberMenageListener.java
+++ b/basic-manager/src/main/java/com/illtamer/infinite/bot/expansion/basic/listener/MemberMenageListener.java
@@ -60,8 +60,7 @@ public class MemberMenageListener implements Listener {
         if (!autoRename || !StaticAPI.inGroups(event.getGroupId())) {
             return;
         }
-        // 是否修改群管理名片校验
-        if (!event.getSender().getRole().equals("member") && !changeAdmin) {
+        if (!changeAdmin && event.getSender().getRole().equals("admin")) {
             return;
         }
         Bukkit.getScheduler().runTaskAsynchronously(Bootstrap.getInstance(), () -> {

--- a/basic-manager/src/main/resources/config.yml
+++ b/basic-manager/src/main/resources/config.yml
@@ -38,6 +38,8 @@ member-manage:
   # 默认群名片
   # 当成员未绑定角色时，设置为该名片
   default-card: '待绑定'
+  # 是否修改群管理员的名片
+  change-admin: false
   # 群成员加入时欢迎语 (自动@该成员)
   # 局部变量 {0}-成员QQ
   welcome:

--- a/chat-manager/src/main/java/com/illtamer/infinite/bot/expansion/chat/listener/Group2GameListener.java
+++ b/chat-manager/src/main/java/com/illtamer/infinite/bot/expansion/chat/listener/Group2GameListener.java
@@ -3,6 +3,7 @@ package com.illtamer.infinite.bot.expansion.chat.listener;
 import com.illtamer.infinite.bot.api.entity.Group;
 import com.illtamer.infinite.bot.api.entity.TransferEntity;
 import com.illtamer.infinite.bot.api.entity.transfer.*;
+import com.illtamer.infinite.bot.api.entity.transfer.Record;
 import com.illtamer.infinite.bot.api.event.message.GroupMessageEvent;
 import com.illtamer.infinite.bot.api.handler.OpenAPIHandling;
 import com.illtamer.infinite.bot.api.message.Message;
@@ -125,11 +126,15 @@ public class Group2GameListener implements Listener {
         public Format(int parseLevel, GroupMessageEvent event) {
             this.parseLevel = parseLevel;
             this.senderId = event.getSender().getUserId();
+            String senderName = event.getSender().getCard();
+            senderName = senderName.trim().length() == 0 ? event.getSender().getNickname() : senderName;
+            senderName = senderName.trim().length() == 0 ? String.valueOf(event.getSender().getUserId()) : senderName;
             this.replacedPrefix = prefix
                     .replace("%group_id%", event.getGroupId().toString())
                     .replace("%group_card%", getGroupName(event.getGroupId()))
                     .replace("%sender_id%", senderId.toString())
-                    .replace("%sender_card%", event.getSender().getCard());
+                    .replace("%sender_card%", event.getSender().getCard())
+                    .replace("%sender_name%", senderName);
             this.message = event.getMessage();
         }
 

--- a/chat-manager/src/main/resources/config.yml
+++ b/chat-manager/src/main/resources/config.yml
@@ -39,7 +39,8 @@ group-to-game:
   # - %group_card% 发送消息的群昵称
   # - %sender_id%: 发送消息的用户qq
   # - %sender_card% 发送消息的用户昵称
-  prefix: '(%group_id%) &6&l[&3&l%sender_card%&6&l]&f'
+  # - %sender_name% 发送消息的群名片,失败则用户昵称,还失败则QQ号
+  prefix: '(%group_id%) &6&l[&3&l%sender_name%&6&l]&f'
   # 消息发送方式
   # - 'global': 控制台 console 发送消息，不可被屏蔽，
   #             注意：在此方式下消息解析等级始终为 0


### PR DESCRIPTION
bug fix: 修复自动改群名片失效问题 
add: 新增 change-admin # 否修改群管理员的名片 配置
add: 新增 %sender_name% 占位符, 提高转发的易用性