### PR TITLE
Improve the generation of online player list msg

### DIFF
--- a/basic-manager/src/main/java/com/illtamer/infinite/bot/expansion/basic/listener/KeyWordsListener.java
+++ b/basic-manager/src/main/java/com/illtamer/infinite/bot/expansion/basic/listener/KeyWordsListener.java
@@ -132,14 +132,14 @@ public class KeyWordsListener implements Listener {
                 return;
             }
             String opPrefix = "\n管理员：", playerPrefix = "\n玩家：";
-            StringBuilder opList = new StringBuilder(opPrefix);
-            StringBuilder playerList = new StringBuilder(playerPrefix);
+            StringJoiner opList = new StringJoiner(", ", opPrefix, "");
+            StringJoiner playerList = new StringJoiner(", ", playerPrefix, "");
             while (iterator.hasNext()) {
                 Player player = iterator.next();
                 if (player.isOp()) {
-                    opList.append(PluginUtil.clearColor(player.getDisplayName())).append(", ");
+                    opList.add(PluginUtil.clearColor(player.getDisplayName()));
                 } else {
-                    playerList.append(PluginUtil.clearColor(player.getDisplayName())).append(", ");
+                    playerList.add(PluginUtil.clearColor(player.getDisplayName()));
                 }
             }
             String format = String.format(language.get("key-word", "show-player"),


### PR DESCRIPTION
The former generating method leaves an extra comma ( " , " ) at the end of the message, as shown below:

玩家：A, B, 

Hardly will a user fail to notice the comma after the player name "B". In order to remove the unused comma after the last player name, I have changed the generation process of the player list message string.

Previously, the message was generated using String Builder. That is to say, for each of the player, the plugin appends the player's name and then adds a comma to divide between names. This will also apply to the last player, and thus an extra comma is presented.

Now I will utilize String Joiner. String joiner is such a tool that it connects two elements with the given delimiter. For example, when you add A and B to a joiner and set the delimiter to a comma and a space ( ", " ), you will get this: "A, B". Apparently, String Joiner is designed to pretty print a list because it neatly tackles the problem of removing the delimiter at the end of the list. 

Hopefully you may accept my PR. Thanks very much for your inspection on my code and explanation.